### PR TITLE
Reword description for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository contains the database connection, ORM, queries, and schema for Postgres to be used across the project. 
 
-This repo is depended on the following components: 
+The following components depend on this repo:
 - https://github.com/target/consensource-api
 - https://github.com/target/consensource-sds


### PR DESCRIPTION
Rewording description to `The following components depend on this repo`.

The old description, `This repo is depended on the following components`, is suppose to be the other way around.

