### PR TITLE
Remove 'batch_id' and 'transaction_id' from user model

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -171,8 +171,6 @@ pub struct NewCertificateData {
 #[derive(Queryable, Insertable, Clone)]
 pub struct User {
     pub public_key: String,
-    pub transaction_id: String,
-    pub batch_id: String,
     pub encrypted_private_key: String,
     pub username: String,
     pub hashed_password: String,

--- a/src/tables_schema.rs
+++ b/src/tables_schema.rs
@@ -15,8 +15,6 @@ table! {
 table! {
     users (public_key) {
         public_key -> Varchar,
-        transaction_id -> Varchar,
-        batch_id -> Varchar,
         encrypted_private_key -> Varchar,
         username -> Varchar,
         hashed_password -> Varchar,

--- a/tables/cert_registry_tables.sql
+++ b/tables/cert_registry_tables.sql
@@ -140,8 +140,6 @@ CREATE INDEX IF NOT EXISTS standard_versions_block_index ON standard_versions (e
 
 CREATE TABLE IF NOT EXISTS users (
   public_key                 VARCHAR     PRIMARY KEY,
-  transaction_id             VARCHAR     NOT NULL,
-  batch_id                   VARCHAR     NOT NULL,
   encrypted_private_key      VARCHAR     NOT NULL,
   username                   VARCHAR     NOT NULL  UNIQUE,
   hashed_password            VARCHAR     NOT NULL


### PR DESCRIPTION
Signed-off-by: Patrick-Erichsen <Patrick.Erichsen@target.com>

## Proposed change/fix

Remove the `batch_id` and `transaction_id` fields from the User table/model schemas. We are not storing `User` objects on-chain so these fields should not exist.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

- `cargo build`
