### PR TITLE
Add missing assertion_id index

### DIFF
--- a/tables/cert_registry_tables.sql
+++ b/tables/cert_registry_tables.sql
@@ -163,5 +163,6 @@ CREATE TABLE IF NOT EXISTS assertions (
   data_id                     VARCHAR
 ) INHERITS (chain_record);
 
+CREATE INDEX IF NOT EXISTS assertions_id_index ON assertions (assertion_id);
 CREATE INDEX IF NOT EXISTS assertions_object_id_index ON assertions (object_id);
 CREATE INDEX IF NOT EXISTS assertions_block_index ON assertions (end_block_num);


### PR DESCRIPTION
## Proposed change/fix

Add missing `assertion_id` index. Currently only indices on `object_id` and `block_num`.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`clip`
