### PR TITLE
Change type to assertion_type && reorder table macro columns

### DIFF
--- a/src/tables_schema.rs
+++ b/src/tables_schema.rs
@@ -173,9 +173,9 @@ table! {
     use super::AssertionType;
     assertions (id) {
         id -> Int8,
-        assertion_id -> VarChar,
         start_block_num -> Int8,
         end_block_num -> Int8,
+        assertion_id -> VarChar,
         assertor_pub_key -> VarChar,
         assertion_type -> AssertionType,
         object_id -> VarChar,

--- a/tables/cert_registry_tables.sql
+++ b/tables/cert_registry_tables.sql
@@ -158,7 +158,7 @@ CREATE TABLE IF NOT EXISTS assertions (
   id                          BIGSERIAL      PRIMARY KEY,
   assertion_id                VARCHAR        NOT NULL,
   assertor_pub_key            VARCHAR        NOT NULL,
-  type                        AssertionType  NOT NULL,
+  assertion_type              AssertionType  NOT NULL,
   object_id                   VARCHAR        NOT NULL,
   data_id                     VARCHAR
 ) INHERITS (chain_record);


### PR DESCRIPTION
## Proposed change/fix

- Change order of columns used in the `table!` macro to align with the SQL definition
- Rename `type` -> `assertion_type` for consistency

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test
`clip`
