### PR TITLE
Update addresses to support full text search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ r2d2-diesel = {version = "1.0.0"}
 serde = "1.0"
 serde_derive = "1.0"
 log = "0.3"
+diesel_full_text_search = "1.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,4 @@ extern crate serde_derive;
 extern crate serde;
 #[macro_use]
 extern crate log;
+extern crate diesel_full_text_search;

--- a/src/models.rs
+++ b/src/models.rs
@@ -64,6 +64,32 @@ pub struct Address {
     pub postal_code: Option<String>,
 }
 
+type AddressColumns = (
+    addresses::id,
+    addresses::start_block_num,
+    addresses::end_block_num,
+    addresses::organization_id,
+    addresses::street_line_1,
+    addresses::street_line_2,
+    addresses::city,
+    addresses::state_province,
+    addresses::country,
+    addresses::postal_code,
+);
+
+pub const ADDRESS_COLUMNS: AddressColumns = (
+    addresses::id,
+    addresses::start_block_num,
+    addresses::end_block_num,
+    addresses::organization_id,
+    addresses::street_line_1,
+    addresses::street_line_2,
+    addresses::city,
+    addresses::state_province,
+    addresses::country,
+    addresses::postal_code,
+);
+
 #[derive(Debug, PartialEq, Queryable, Insertable)]
 #[table_name = "addresses"]
 pub struct NewAddress {

--- a/src/tables_schema.rs
+++ b/src/tables_schema.rs
@@ -68,6 +68,8 @@ table! {
 }
 
 table! {
+    use diesel_full_text_search::{TsVector as Tsvector};
+    use diesel::sql_types::*;
     addresses (id) {
         id -> Int8,
         start_block_num -> Int8,
@@ -79,6 +81,7 @@ table! {
         state_province -> Nullable<Varchar>,
         country -> Varchar,
         postal_code -> Nullable<Varchar>,
+        text_searchable_address_col -> Tsvector,
     }
 }
 

--- a/tables/cert_registry_tables.sql
+++ b/tables/cert_registry_tables.sql
@@ -99,11 +99,18 @@ CREATE TABLE IF NOT EXISTS addresses (
   city               VARCHAR     NOT NULL,
   state_province     VARCHAR,
   country            VARCHAR     NOT NULL,
-  postal_code        VARCHAR
+  postal_code        VARCHAR,
+  text_searchable_address_col   TSVECTOR
 ) INHERITS (chain_record);
 
 CREATE INDEX IF NOT EXISTS addresses_organization_id_index ON addresses (organization_id);
 CREATE INDEX IF NOT EXISTS addresses_block_index ON addresses (end_block_num);
+CREATE INDEX IF NOT EXISTS address_text_search ON addresses USING GIN (text_searchable_address_col);
+
+CREATE TRIGGER tsvectorupdateaddresses BEFORE INSERT OR UPDATE
+ON addresses FOR EACH ROW EXECUTE PROCEDURE
+tsvector_update_trigger(text_searchable_address_col, 'pg_catalog.english',
+  street_line_1, street_line_2, city, state_province, country, postal_code);
 
 CREATE TABLE IF NOT EXISTS certificate_data (
   id                         BIGSERIAL   PRIMARY KEY,


### PR DESCRIPTION
## Proposed change/fix

Use postgres full text search options to enable one stop shop address searching. See [here](https://www.postgresql.org/docs/9.5/textsearch.html) for documentation. This change adds a `TsVector` column to the address table that does not get returned by the diesel model, requiring the addition of the `ADDRESS_COLUMNS` constant when `SELECT`ing addresses. See example in the [api repo](https://github.com/target/consensource-api/pull/24) for usage.

## Types of changes

What types of changes does this pull request introduce to ConsenSource? _Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (could be a small readme update, documentation contribution, etc.)

## How to run/test

`clip`
`cargo build`